### PR TITLE
Updated flag "--image-pull-policy"

### DIFF
--- a/cmd/fledged.go
+++ b/cmd/fledged.go
@@ -90,5 +90,6 @@ func init() {
 	flag.DurationVar(&imagePullDeadlineDuration, "image-pull-deadline-duration", time.Minute*5, "Maximum duration allowed for pulling an image. After this duration, image pull is considered to have failed")
 	flag.DurationVar(&imageCacheRefreshFrequency, "image-cache-refresh-frequency", time.Minute*15, "The image cache is refreshed periodically to ensure the cache is up to date. Setting this flag to 0s will disable refresh")
 	flag.StringVar(&dockerClientImage, "docker-client-image", "senthilrch/fledged-docker-client:latest", "The image name of the docker client. the docker client is used when deleting images during purging the cache")
-	flag.StringVar(&imagePullPolicy, "image-pull-policy", "", "Image pull policy default value is IfNotPresent. Possible values are IfNotPresent and Always")
+	flag.StringVar(&imagePullPolicy, "image-pull-policy", "", "Image pull policy default value is IfNotPresent. Possible values are IfNotPresent and Always")	
+        flag.StringVar(&imagePullPolicy, "image-pull-policy", "", " Image pull policy for pulling images into the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Default value for Images with ':latest' tag is 'Always'")
 }


### PR DESCRIPTION
flag.StringVar(&imagePullPolicy, "image-pull-policy", "", " Image pull policy for pulling images into the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Default value for Images with ':latest' tag is 'Always'")