### PR TITLE
Issue #17: Image deletion during image cache update & Issue #18 partially

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ For more detailed description, go through _kube-fledged's_ [design proposal](doc
 
 `--docker-client-image:` The image name of the docker client. the docker client is used when deleting images during purging the cache".
 
+`--image-pull-policy:` Image pull policy for pulling images into the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Default value for Images with ':latest' tag is 'Always'
+
 `--stderrthreshold:` Log level. set the value of this flag to INFO
 
 ## Supported Platforms

--- a/cmd/app/controller.go
+++ b/cmd/app/controller.go
@@ -186,19 +186,19 @@ func (c *Controller) danglingImageCaches() error {
 	}
 	status := &fledgedv1alpha1.ImageCacheStatus{
 		Failures: map[string][]fledgedv1alpha1.NodeReasonMessage{},
-		Status:   fledgedv1alpha1.ImageCacheActionStatusAbhorted,
-		Reason:   fledgedv1alpha1.ImageCacheReasonImagePullAbhorted,
-		Message:  fledgedv1alpha1.ImageCacheMessageImagePullAbhorted,
+		Status:   fledgedv1alpha1.ImageCacheActionStatusAborted,
+		Reason:   fledgedv1alpha1.ImageCacheReasonImagePullAborted,
+		Message:  fledgedv1alpha1.ImageCacheMessageImagePullAborted,
 	}
 	for _, imagecache := range imagecachelist.Items {
 		if imagecache.Status.Status == fledgedv1alpha1.ImageCacheActionStatusProcessing {
 			err := c.updateImageCacheStatus(&imagecache, status)
 			if err != nil {
-				glog.Errorf("Error updating ImageCache(%s) status to '%s': %v", imagecache.Name, fledgedv1alpha1.ImageCacheActionStatusAbhorted, err)
+				glog.Errorf("Error updating ImageCache(%s) status to '%s': %v", imagecache.Name, fledgedv1alpha1.ImageCacheActionStatusAborted, err)
 				return err
 			}
 			dangling = true
-			glog.Infof("Dangling Image cache(%s) status changed to '%s'", imagecache.Name, fledgedv1alpha1.ImageCacheActionStatusAbhorted)
+			glog.Infof("Dangling Image cache(%s) status changed to '%s'", imagecache.Name, fledgedv1alpha1.ImageCacheActionStatusAborted)
 		}
 	}
 
@@ -256,7 +256,7 @@ func (c *Controller) enqueueImageCache(workType images.WorkType, old, new interf
 	var key string
 	var err error
 	var obj interface{}
-	var wqKey images.WorkQueueKey
+	wqKey := images.WorkQueueKey{}
 
 	switch workType {
 	case images.ImageCacheCreate:
@@ -299,6 +299,10 @@ func (c *Controller) enqueueImageCache(workType images.WorkType, old, new interf
 	}
 	wqKey.WorkType = workType
 	wqKey.ObjKey = key
+	if workType == images.ImageCacheUpdate {
+		oldImageCache := old.(*fledgedv1alpha1.ImageCache)
+		wqKey.OldImageCache = oldImageCache
+	}
 
 	c.workqueue.AddRateLimited(wqKey)
 
@@ -443,6 +447,49 @@ func (c *Controller) syncHandler(wqKey images.WorkQueueKey) error {
 			return err
 		}
 
+		if wqKey.WorkType == images.ImageCacheUpdate && wqKey.OldImageCache == nil {
+			status.Status = fledgedv1alpha1.ImageCacheActionStatusFailed
+			status.Reason = fledgedv1alpha1.ImageCacheReasonOldImageCacheNotFound
+			status.Message = fledgedv1alpha1.ImageCacheMessageOldImageCacheNotFound
+
+			if err = c.updateImageCacheStatus(imageCache, status); err != nil {
+				glog.Errorf("Error updating imagecache status to %s: %v", status.Status, err)
+				return err
+			}
+
+			return err
+		}
+
+		if wqKey.WorkType == images.ImageCacheUpdate {
+			if len(wqKey.OldImageCache.Spec.CacheSpec) != len(imageCache.Spec.CacheSpec) {
+				status.Status = fledgedv1alpha1.ImageCacheActionStatusFailed
+				status.Reason = fledgedv1alpha1.ImageCacheReasonNotSupportedUpdates
+				status.Message = fledgedv1alpha1.ImageCacheMessageNotSupportedUpdates
+
+				if err = c.updateImageCacheStatus(imageCache, status); err != nil {
+					glog.Errorf("Error updating imagecache status to %s: %v", status.Status, err)
+					return err
+				}
+
+				return err
+			}
+
+			for i := range wqKey.OldImageCache.Spec.CacheSpec {
+				if !reflect.DeepEqual(wqKey.OldImageCache.Spec.CacheSpec[i].NodeSelector, imageCache.Spec.CacheSpec[i].NodeSelector) {
+					status.Status = fledgedv1alpha1.ImageCacheActionStatusFailed
+					status.Reason = fledgedv1alpha1.ImageCacheReasonNotSupportedUpdates
+					status.Message = fledgedv1alpha1.ImageCacheMessageNotSupportedUpdates
+
+					if err = c.updateImageCacheStatus(imageCache, status); err != nil {
+						glog.Errorf("Error updating imagecache status to %s: %v", status.Status, err)
+						return err
+					}
+
+					return err
+				}
+			}
+		}
+
 		// add Finalizer to ImageCache resource since we need to have control over when
 		// actual API resource is removed from etcd during delete action
 		if wqKey.WorkType == images.ImageCacheCreate || wqKey.WorkType == images.ImageCacheUpdate {
@@ -490,7 +537,7 @@ func (c *Controller) syncHandler(wqKey images.WorkQueueKey) error {
 			return err
 		}
 
-		for _, i := range cacheSpec {
+		for k, i := range cacheSpec {
 			if len(i.NodeSelector) > 0 {
 				if nodes, err = c.nodesLister.List(labels.Set(i.NodeSelector).AsSelector()); err != nil {
 					glog.Errorf("Error listing nodes using nodeselector %+v: %v", i.NodeSelector, err)
@@ -518,8 +565,29 @@ func (c *Controller) syncHandler(wqKey images.WorkQueueKey) error {
 					}
 					c.imageworkqueue.AddRateLimited(ipr)
 				}
+				if wqKey.WorkType == images.ImageCacheUpdate {
+					for _, oldimage := range wqKey.OldImageCache.Spec.CacheSpec[k].Images {
+						matched := false
+						for _, newimage := range i.Images {
+							if oldimage == newimage {
+								matched = true
+								break
+							}
+						}
+						if !matched {
+							ipr := images.ImageWorkRequest{
+								Image:      oldimage,
+								Node:       n.Labels["kubernetes.io/hostname"],
+								WorkType:   images.ImageCachePurge,
+								Imagecache: imageCache,
+							}
+							c.imageworkqueue.AddRateLimited(ipr)
+						}
+					}
+				}
 			}
 		}
+
 		// We add an empty image pull request to signal the image manager that all
 		// requests for this sync action have been placed in the imageworkqueue
 		c.imageworkqueue.AddRateLimited(images.ImageWorkRequest{WorkType: wqKey.WorkType, Imagecache: imageCache})

--- a/cmd/app/controller.go
+++ b/cmd/app/controller.go
@@ -354,6 +354,7 @@ func (c *Controller) processNextWorkItem() bool {
 		// Run the syncHandler, passing it the namespace/name string of the
 		// ImageCache resource to be synced.
 		if err := c.syncHandler(key); err != nil {
+			glog.Errorf("error syncing imagecache: %v", err.Error())
 			return fmt.Errorf("error syncing imagecache: %v", err.Error())
 		}
 		// Finally, if no error occurs we Forget this item so it does not
@@ -456,8 +457,8 @@ func (c *Controller) syncHandler(wqKey images.WorkQueueKey) error {
 				glog.Errorf("Error updating imagecache status to %s: %v", status.Status, err)
 				return err
 			}
-
-			return err
+			glog.Errorf("%s: %s", fledgedv1alpha1.ImageCacheReasonOldImageCacheNotFound, fledgedv1alpha1.ImageCacheMessageOldImageCacheNotFound)
+			return fmt.Errorf("%s: %s", fledgedv1alpha1.ImageCacheReasonOldImageCacheNotFound, fledgedv1alpha1.ImageCacheMessageOldImageCacheNotFound)
 		}
 
 		if wqKey.WorkType == images.ImageCacheUpdate {
@@ -470,8 +471,8 @@ func (c *Controller) syncHandler(wqKey images.WorkQueueKey) error {
 					glog.Errorf("Error updating imagecache status to %s: %v", status.Status, err)
 					return err
 				}
-
-				return err
+				glog.Errorf("%s: %s", fledgedv1alpha1.ImageCacheReasonNotSupportedUpdates, "Mismatch in no. of image lists")
+				return fmt.Errorf("%s: %s", fledgedv1alpha1.ImageCacheReasonNotSupportedUpdates, "Mismatch in no. of image lists")
 			}
 
 			for i := range wqKey.OldImageCache.Spec.CacheSpec {
@@ -484,8 +485,8 @@ func (c *Controller) syncHandler(wqKey images.WorkQueueKey) error {
 						glog.Errorf("Error updating imagecache status to %s: %v", status.Status, err)
 						return err
 					}
-
-					return err
+					glog.Errorf("%s: %s", fledgedv1alpha1.ImageCacheReasonNotSupportedUpdates, "Mismatch in node selector")
+					return fmt.Errorf("%s: %s", fledgedv1alpha1.ImageCacheReasonNotSupportedUpdates, "Mismatch in node selector")
 				}
 			}
 		}

--- a/pkg/apis/fledged/v1alpha1/types.go
+++ b/pkg/apis/fledged/v1alpha1/types.go
@@ -79,7 +79,7 @@ const (
 	ImageCacheActionStatusSucceeded  ImageCacheActionStatus = "Succeeded"
 	ImageCacheActionStatusFailed     ImageCacheActionStatus = "Failed"
 	ImageCacheActionStatusUnknown    ImageCacheActionStatus = "Unknown"
-	ImageCacheActionStatusAbhorted   ImageCacheActionStatus = "Abhorted"
+	ImageCacheActionStatusAborted    ImageCacheActionStatus = "Aborted"
 )
 
 // List of constants for ImageCacheReason
@@ -95,8 +95,10 @@ const (
 	ImageCacheReasonImageDeleteFailedForSomeImages = "ImageDeleteFailedForSomeImages"
 	ImageCacheReasonImagePullFailedOnSomeNodes     = "ImagePullFailedOnSomeNodes"
 	ImageCacheReasonImagePullStatusUnknown         = "ImagePullStatusUnknown"
-	ImageCacheReasonImagePullAbhorted              = "ImagePullAbhorted"
+	ImageCacheReasonImagePullAborted               = "ImagePullAborted"
 	ImageCacheReasonCacheSpecValidationFailed      = "CacheSpecValidationFailed"
+	ImageCacheReasonOldImageCacheNotFound          = "OldImageCacheNotFound"
+	ImageCacheReasonNotSupportedUpdates            = "NotSupportedUpdates"
 )
 
 // List of constants for ImageCacheMessage
@@ -112,5 +114,7 @@ const (
 	ImageCacheMessageImageDeleteFailedForSomeImages = "Image deletion failed for some images. Please see \"failures\" section"
 	ImageCacheMessageImagePullFailedOnSomeNodes     = "Image pull failed on some nodes. Please see \"failures\" section"
 	ImageCacheMessageImagePullStatusUnknown         = "Unable to get the status of Image pull. Retry after some time or contact cluster administrator"
-	ImageCacheMessageImagePullAbhorted              = "Image cache processing abhorted. Image cache will get refreshed during next refresh cycle"
+	ImageCacheMessageImagePullAborted               = "Image cache processing aborted. Image cache will get refreshed during next refresh cycle"
+	ImageCacheMessageOldImageCacheNotFound          = "Unable to fetch the previous version of Image cache spec before update action."
+	ImageCacheMessageNotSupportedUpdates            = "The updates performed to image cache spec is not supported. Only addition or removal of images in a image list is supported."
 )

--- a/pkg/images/image_manager.go
+++ b/pkg/images/image_manager.go
@@ -161,7 +161,11 @@ func (m *ImageManager) handlePodStatusChange(pod *corev1.Pod) {
 
 	if pod.Status.Phase == corev1.PodSucceeded {
 		iwres.Status = ImageWorkResultStatusSucceeded
-		glog.Infof("Job %s succeeded (%s --> %s)", pod.Labels["job-name"], iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+		if iwres.ImageWorkRequest.WorkType == ImageCachePurge {
+			glog.Infof("Job %s succeeded (delete: %s --> %s)", pod.Labels["job-name"], iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+		} else {
+			glog.Infof("Job %s succeeded (pull: %s --> %s)", pod.Labels["job-name"], iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+		}
 	}
 	if pod.Status.Phase == corev1.PodFailed {
 		iwres.Status = ImageWorkResultStatusFailed
@@ -169,7 +173,11 @@ func (m *ImageManager) handlePodStatusChange(pod *corev1.Pod) {
 			iwres.Reason = pod.Status.ContainerStatuses[0].State.Terminated.Reason
 			iwres.Message = pod.Status.ContainerStatuses[0].State.Terminated.Message
 		}
-		glog.Infof("Job %s failed (%s --> %s)", pod.Labels["job-name"], iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+		if iwres.ImageWorkRequest.WorkType == ImageCachePurge {
+			glog.Infof("Job %s failed (delete: %s --> %s)", pod.Labels["job-name"], iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+		} else {
+			glog.Infof("Job %s failed (pull: %s --> %s)", pod.Labels["job-name"], iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+		}
 	}
 	m.lock.Lock()
 	m.imageworkstatus[pod.Labels["job-name"]] = iwres
@@ -198,6 +206,11 @@ func (m *ImageManager) updatePendingImageWorkResults(imageCacheName string) erro
 					return fmt.Errorf("More than one pod matched job %s", job)
 				}
 				iwres.Status = ImageWorkResultStatusFailed
+				if iwres.ImageWorkRequest.WorkType == ImageCachePurge {
+					glog.Infof("Job %s expired (delete: %s --> %s)", job, iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+				} else {
+					glog.Infof("Job %s expired (pull: %s --> %s)", job, iwres.ImageWorkRequest.Image, iwres.ImageWorkRequest.Node)
+				}
 				if pods[0].Status.Phase == corev1.PodPending {
 					if pods[0].Status.ContainerStatuses[0].State.Waiting != nil {
 						iwres.Reason = pods[0].Status.ContainerStatuses[0].State.Waiting.Reason
@@ -373,11 +386,13 @@ func (m *ImageManager) processNextWorkItem() bool {
 			if err != nil {
 				return fmt.Errorf("error deleting image '%s' from node '%s': %s", iwr.Image, iwr.Node, err.Error())
 			}
+			glog.Infof("Job %s created (delete: %s --> %s)", job.Name, iwr.Image, iwr.Node)
 		} else {
 			job, err = m.pullImage(iwr)
 			if err != nil {
 				return fmt.Errorf("error pulling image '%s' to node '%s': %s", iwr.Image, iwr.Node, err.Error())
 			}
+			glog.Infof("Job %s created (pull: %s --> %s)", job.Name, iwr.Image, iwr.Node)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
@@ -385,7 +400,6 @@ func (m *ImageManager) processNextWorkItem() bool {
 		m.imageworkstatus[job.Name] = ImageWorkResult{ImageWorkRequest: iwr, Status: ImageWorkResultStatusJobCreated}
 		m.lock.Unlock()
 		m.imageworkqueue.Forget(obj)
-		glog.Infof("Job %s created (%s --> %s)", job.Name, iwr.Image, iwr.Node)
 		return nil
 	}(obj)
 

--- a/pkg/images/image_manager.go
+++ b/pkg/images/image_manager.go
@@ -94,9 +94,10 @@ const (
 
 // WorkQueueKey is an item in the sync handler's work queue
 type WorkQueueKey struct {
-	WorkType WorkType
-	ObjKey   string
-	Status   *map[string]ImageWorkResult
+	WorkType      WorkType
+	ObjKey        string
+	Status        *map[string]ImageWorkResult
+	OldImageCache *fledgedv1alpha1.ImageCache
 }
 
 // NewImageManager returns a new image manager object


### PR DESCRIPTION
### This PR implements following enhancements:-

- Issue #17 : Image deletion during image cache update
- Issue #18 : Increase unit test code coverage to > 75% (partially)

### When a user updates the ImageCache.Spec, following restrictions apply:-
- allowed to add new images to an image list
- allowed to remove images from an image list
- any other updates like adding a new image list (or) removing an image list (or) modifying the node selector of an image list are not allowed.

**Also note:-**  _when validation of above restrictions fail, the spec will **not be restored** back to the original contents since restoring will re-trigger an infinite loop of re-syncs_