### PR TITLE
Move custom resource definitions to crds directory

### DIFF
--- a/deploy/kubefledged-operator/helm-charts/kubefledged/Chart.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: v0.7.1
+version: v0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/crds/crd.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/crds/crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: imagecaches.kubefledged.k8s.io
-  labels:
-{{ include "kubefledged.labels" . | nindent 4 }}
 spec:
   group: kubefledged.k8s.io
   versions:


### PR DESCRIPTION
Migrated the `templates/crd.yaml` resources to the `crds` directory so that the custom resource definitions get installed before anything else. This then permits also properly creating `ImageCache` resources as part of the install of another chart that includes this one. For details on this pattern, see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/