### PR TITLE
[Helm Chart] Ensure validating webhook configuration client config service name  is correct

### DIFF
--- a/deploy/kubefledged-operator/helm-charts/kubefledged/Chart.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: v0.8.0
+version: v0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/templates/_helpers.tpl
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Create the name of the service for the webhook server to use
 */}}
 {{- define "kubefledged.webhookServiceName" -}}
 {{- if .Values.webhookService.create -}}
-    {{ default (include "kubefledged.fullname" .) .Values.webhookService.name }}
+    {{ default ( printf "%s-webhook-server" (include "kubefledged.fullname" .)) .Values.webhookService.name }}
 {{- else -}}
     {{ default "default" .Values.webhookService.name }}
 {{- end -}}

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/templates/service-webhook-server.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/templates/service-webhook-server.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kubefledged.fullname" . }}-webhook-server
+  name: {{ include "kubefledged.webhookServiceName" . }}
   labels:
     {{ include "kubefledged.labels" . | nindent 4 }}
   namespace: {{ .Values.kubefledgedNameSpace }}

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/templates/validatingwebhook.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/templates/validatingwebhook.yaml
@@ -12,7 +12,7 @@ webhooks:
     clientConfig:
       service:
         namespace: {{ .Values.kubefledgedNameSpace }}
-        name: kubefledged-webhook-server
+        name: {{ include "kubefledged.webhookServiceName" . }}
         path: "/validate-image-cache"
         port: {{ .Values.webhookService.port }}
       caBundle: {{ .Values.validatingWebhookCABundle }}


### PR DESCRIPTION
Currently the `ValidatingWebhookConfiguration` resource has the `cliencConfig.service.name` hardcoded, when instead it should be set to whatever the webhook server service name is; this pr addresses that issue. 