### PR TITLE
Fix failing go tests

### DIFF
--- a/cmd/controller/app/controller_test.go
+++ b/cmd/controller/app/controller_test.go
@@ -182,6 +182,10 @@ func TestPreFlightChecks(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "foo",
+							Labels: map[string]string{
+								"app":         "kubefledged",
+								"kubefledged": "kubefledged-image-manager",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Fix failing go test cases (#135)

**What?**
Test case 6: _One dangling job. Successful list. Unsuccessful delete_ (**TestPreFlightChecks**) was failing with `panic: runtime error: invalid memory address or nil pointer dereference` 

**Why?**
danglingJobs() filters the jobList on the basis of following LabelSelector - `app=kubefledged,kubefledged=kubefledged-image-manager` but these Labels were not set in the test data. 

**Solution**
Passed the map with the above labels in the test data

```
make test
rm -f coverage.out
bash hack/run-unit-tests.sh
?   	github.com/senthilrch/kube-fledged/cmd/controller	[no test files]
=== RUN   TestPreFlightChecks
E0308 11:08:13.338100    2460 controller.go:164] Error listing jobs: Internal error occurred: fake error
E0308 11:08:13.338820    2460 controller.go:191] Error listing imagecaches: Internal error occurred: fake error
E0308 11:08:13.338886    2460 controller.go:177] Error deleting job(foo): Internal error occurred: fake error
E0308 11:08:13.338958    2460 controller.go:210] Error updating ImageCache(foo) status to 'Aborted': Internal error occurred: fake error
    controller_test.go:279: 7 tests passed
--- PASS: TestPreFlightChecks (0.00s)
=== RUN   TestRunRefreshWorker
--- PASS: TestRunRefreshWorker (0.00s)
=== RUN   TestSyncHandler
E0308 11:08:13.339789    2460 controller.go:436] Error from cache.SplitMetaNamespaceKey(): unexpected key format: "foo/bar/car"
E0308 11:08:13.339860    2460 controller.go:465] OldImageCacheNotFound: Unable to fetch the previous version of Image cache spec before update action.
E0308 11:08:13.339907    2460 controller.go:502] Error updating imagecache status to Processing: Internal error occurred: fake error
E0308 11:08:13.340009    2460 controller.go:502] Error updating imagecache status to Processing: Internal error occurred: fake error
    controller_test.go:874: 12 tests passed
--- PASS: TestSyncHandler (0.00s)
=== RUN   TestEnqueueImageCache
--- PASS: TestEnqueueImageCache (0.00s)
=== RUN   TestProcessNextWorkItem
E0308 11:08:13.341607    2460 controller.go:371] unexpected type in workqueue: struct {}{}
    controller_test.go:1182: 3 tests passed
--- PASS: TestProcessNextWorkItem (0.00s)
PASS
coverage: 79.4% of statements
ok  	github.com/senthilrch/kube-fledged/cmd/controller/app	0.284s	coverage: 79.4% of statements
?   	github.com/senthilrch/kube-fledged/cmd/webhook-server	[no test files]
?   	github.com/senthilrch/kube-fledged/cmd/webhook-server/app	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/apis/kubefledged	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/apis/kubefledged/v1alpha2	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/clientset/versioned	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/clientset/versioned/fake	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/clientset/versioned/scheme	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/clientset/versioned/typed/kubefledged/v1alpha2	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/clientset/versioned/typed/kubefledged/v1alpha2/fake	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/informers/externalversions	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/informers/externalversions/kubefledged	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/informers/externalversions/kubefledged/v1alpha2	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/client/listers/kubefledged/v1alpha2	[no test files]
=== RUN   TestPullDeleteImage
E0308 11:08:13.714367    2461 image_helpers.go:38] imagecache pointer is nil
E0308 11:08:13.716427    2461 image_manager.go:492] Error when constructing job manifest: imagecache pointer is nil
E0308 11:08:13.716481    2461 image_manager.go:498] Error creating job in node &Node{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[kubernetes.io/hostname:bar] map[] [] []  []},Spec:NodeSpec{PodCIDR:,DoNotUseExternalID:,ProviderID:,Unschedulable:false,Taints:[]Taint{},ConfigSource:nil,PodCIDRs:[],},Status:NodeStatus{Capacity:ResourceList{},Allocatable:ResourceList{},Phase:,Conditions:[]NodeCondition{},Addresses:[]NodeAddress{},DaemonEndpoints:NodeDaemonEndpoints{KubeletEndpoint:DaemonEndpoint{Port:0,},},NodeInfo:NodeSystemInfo{MachineID:,SystemUUID:,BootID:,KernelVersion:,OSImage:,ContainerRuntimeVersion:,KubeletVersion:,KubeProxyVersion:,OperatingSystem:,Architecture:,},Images:[]ContainerImage{},VolumesInUse:[],VolumesAttached:[]AttachedVolume{},Config:nil,},}: Internal error occurred: fake error
E0308 11:08:13.716714    2461 image_helpers.go:142] imagecache pointer is nil
E0308 11:08:13.716720    2461 image_manager.go:509] Error when constructing job manifest: imagecache pointer is nil
E0308 11:08:13.716753    2461 image_manager.go:515] Error creating job in node &Node{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[kubernetes.io/hostname:bar] map[] [] []  []},Spec:NodeSpec{PodCIDR:,DoNotUseExternalID:,ProviderID:,Unschedulable:false,Taints:[]Taint{},ConfigSource:nil,PodCIDRs:[],},Status:NodeStatus{Capacity:ResourceList{},Allocatable:ResourceList{},Phase:,Conditions:[]NodeCondition{},Addresses:[]NodeAddress{},DaemonEndpoints:NodeDaemonEndpoints{KubeletEndpoint:DaemonEndpoint{Port:0,},},NodeInfo:NodeSystemInfo{MachineID:,SystemUUID:,BootID:,KernelVersion:,OSImage:,ContainerRuntimeVersion:,KubeletVersion:,KubeProxyVersion:,OperatingSystem:,Architecture:,},Images:[]ContainerImage{},VolumesInUse:[],VolumesAttached:[]AttachedVolume{},Config:nil,},}: Internal error occurred: fake error
--- PASS: TestPullDeleteImage (0.00s)
=== RUN   TestHandlePodStatusChange
--- PASS: TestHandlePodStatusChange (0.00s)
=== RUN   TestUpdateImageCacheStatus
E0308 11:08:13.794695    2461 image_manager.go:229] More than one pod matched job fakejob
E0308 11:08:13.794709    2461 image_manager.go:312] Error from updatePendingImageWorkResults(): more than one pod matched job fakejob
    image_manager_test.go:631: err=more than one pod matched job fakejob
--- PASS: TestUpdateImageCacheStatus (0.09s)
=== RUN   TestProcessNextWorkItem
E0308 11:08:13.808417    2461 image_manager.go:424] unexpected type in workqueue: struct {}{}
--- PASS: TestProcessNextWorkItem (0.00s)
PASS
coverage: 81.5% of statements
ok  	github.com/senthilrch/kube-fledged/pkg/images	0.750s	coverage: 81.5% of statements
?   	github.com/senthilrch/kube-fledged/pkg/signals	[no test files]
?   	github.com/senthilrch/kube-fledged/pkg/webhook	[no test files]
```