### PR TITLE
feat(ImageManager): add --job-retention-policy flag to the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ For more detailed description, go through _kube-fledged's_ [design proposal](doc
 
 `--job-priority-class-name:` priorityClassName of jobs created by kubefledged-controller.
 
-`--job-retention-policy:` Set if an Image Manager Kubernetes Job API object will be deleted or retained (for debugging) after it finishes. Possible values are 'delete' and 'retain', defaults to 'delete'.
+`--job-retention-policy:` Determines if the jobs created by kubefledged-controller would be deleted or retained (for debugging) after it finishes. Possible values are 'delete' and 'retain'. default value is 'delete'.
 
 `--service-account-name:` serviceAccountName used in Jobs created for pulling or deleting images. Optional flag. If not specified the default service account of the namespace is used
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ For more detailed description, go through _kube-fledged's_ [design proposal](doc
 
 `--job-priority-class-name:` priorityClassName of jobs created by kubefledged-controller.
 
+`--job-retention-policy:` Set if an Image Manager Kubernetes Job API object will be deleted or retained (for debugging) after it finishes. Possible values are 'delete' and 'retain', defaults to 'delete'.
+
 `--service-account-name:` serviceAccountName used in Jobs created for pulling or deleting images. Optional flag. If not specified the default service account of the namespace is used
 
 `--stderrthreshold:` Log level. set the value of this flag to INFO

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -98,7 +98,8 @@ func NewController(
 	imagePullPolicy string,
 	serviceAccountName string,
 	imageDeleteJobHostNetwork bool,
-	jobPriorityClassName string) *Controller {
+	jobPriorityClassName string,
+	canDeleteJob bool) *Controller {
 
 	runtime.Must(fledgedscheme.AddToScheme(scheme.Scheme))
 	glog.V(4).Info("Creating event broadcaster")
@@ -124,7 +125,7 @@ func NewController(
 	imageManager, _ := images.NewImageManager(controller.workqueue, controller.imageworkqueue,
 		controller.kubeclientset, controller.fledgedNameSpace, imagePullDeadlineDuration,
 		criClientImage, busyboxImage, imagePullPolicy, serviceAccountName, imageDeleteJobHostNetwork,
-		jobPriorityClassName)
+		jobPriorityClassName, canDeleteJob)
 	controller.imageManager = imageManager
 
 	glog.Info("Setting up event handlers")

--- a/cmd/controller/app/controller_test.go
+++ b/cmd/controller/app/controller_test.go
@@ -66,6 +66,7 @@ func newTestController(kubeclientset kubernetes.Interface, fledgedclientset clie
 	serviceAccountName := "sa-kube-fledged"
 	imageDeleteJobHostNetwork := false
 	jobPriorityClassName := "priority-class-kube-fledged"
+	canDelete := false
 
 	/* 	startInformers := true
 	   	if startInformers {
@@ -79,7 +80,7 @@ func newTestController(kubeclientset kubernetes.Interface, fledgedclientset clie
 		fledgedclientset, fledgedNameSpace, nodeInformer, imagecacheInformer,
 		imageCacheRefreshFrequency, imagePullDeadlineDuration, criClientImage,
 		busyboxImage, imagePullPolicy, serviceAccountName, imageDeleteJobHostNetwork,
-		jobPriorityClassName)
+		jobPriorityClassName, canDelete)
 	controller.nodesSynced = func() bool { return true }
 	controller.imageCachesSynced = func() bool { return true }
 	return controller, nodeInformer, imagecacheInformer

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -109,7 +109,6 @@ func init() {
 	flag.StringVar(&serviceAccountName, "service-account-name", "", "serviceAccountName used in Jobs created for pulling/deleting images. Optional flag. If not specified the default service account of the namespace is used")
 	flag.BoolVar(&imageDeleteJobHostNetwork, "image-delete-job-host-network", false, "whether the pod for the image delete job should be run with 'HostNetwork: true'. Default value: false")
 	flag.StringVar(&jobPriorityClassName, "job-priority-class-name", "", "priorityClassName of jobs created by kubefledged-controller")
-
 	flag.Func("job-retention-policy", "sets the retention behavior of finished Image Manager Jobs (default: 'delete')",
 		func(val string) error {
 			const (

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -113,22 +113,22 @@ func init() {
 	flag.Func("job-retention-policy", "sets the retention behavior of finished Image Manager Jobs (default: 'delete')",
 		func(val string) error {
 			const (
-				DELETE_POLICY string = "delete"
-				RETAIN_POLICY string = "retain"
+				deletePolicy string = "delete"
+				retainPolicy string = "retain"
 			)
 			switch strings.ToLower(strings.TrimSpace(val)) {
-			case DELETE_POLICY:
+			case deletePolicy:
 				canDeleteJob = true
-				glog.Infof("Using '%s' Job Retention Policy", DELETE_POLICY)
+				glog.Infof("Using '%s' Job Retention Policy", deletePolicy)
 				return nil
-			case RETAIN_POLICY:
+			case retainPolicy:
 				canDeleteJob = false
-				glog.Infof("Using '%s' Job Retention Policy", RETAIN_POLICY)
+				glog.Infof("Using '%s' Job Retention Policy", retainPolicy)
 				return nil
 			default:
 				//canDeleteJob is initialized to true already
 				glog.Infof("Failed to set '%s' Job Retention Policy -- invalid input:"+
-					" falling back to '%s' Job Retention Policy", val, DELETE_POLICY)
+					" falling back to '%s' Job Retention Policy", val, deletePolicy)
 				return nil
 			}
 		},

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,7 +45,8 @@ var (
 	serviceAccountName         string
 	imageDeleteJobHostNetwork  bool
 	jobPriorityClassName       string
-	canDeleteJob               bool
+	//Default value for when `--job-retention-policy` flag is not set
+	canDeleteJob bool = true
 )
 
 func main() {
@@ -125,8 +126,9 @@ func init() {
 				glog.Infof("Using '%s' Job Retention Policy", RETAIN_POLICY)
 				return nil
 			default:
-				canDeleteJob = true
-				glog.Infof("Defaulting to '%s' Job Retention Policy", DELETE_POLICY)
+				//canDeleteJob is initialized to true already
+				glog.Infof("Failed to set '%s' Job Retention Policy -- invalid input:"+
+					" falling back to '%s' Job Retention Policy", val, DELETE_POLICY)
 				return nil
 			}
 		},

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/README.md
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/README.md
@@ -52,6 +52,7 @@ Kube-fledged is a kubernetes operator for creating and managing a cache of conta
 | args.controllerImagePullDeadlineDuration | 5m | Maximum duration allowed for pulling an image. After this duration, image pull is considered to have failed |
 | args.controllerImagePullPolicy | IfNotPresent | Image pull policy for pulling images into and refreshing the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Image with no or ":latest" tag are always pulled |
 | args.controllerJobPriorityClassName | "" | priorityClassName of jobs created by kubefledged-controller. If not specified, priorityClassName won't be set |
+| args.controllerJobRetentionPolicy | "delete" | Set Job delete/retain behavior of controller after a Job finishes |
 | args.controllerServiceAccountName | "" | serviceAccountName used in Jobs created for pulling or deleting images. Optional flag. If not specified the default service account of the namespace is used |
 | args.controllerLogLevel | INFO | Log level of kubefledged-controller |
 | args.webhookServerCertFile | /var/run/secrets/webhook-server/tls.crt | Path of server certificate of kubefledged-webhook-server |

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/README.md
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/README.md
@@ -52,7 +52,7 @@ Kube-fledged is a kubernetes operator for creating and managing a cache of conta
 | args.controllerImagePullDeadlineDuration | 5m | Maximum duration allowed for pulling an image. After this duration, image pull is considered to have failed |
 | args.controllerImagePullPolicy | IfNotPresent | Image pull policy for pulling images into and refreshing the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Image with no or ":latest" tag are always pulled |
 | args.controllerJobPriorityClassName | "" | priorityClassName of jobs created by kubefledged-controller. If not specified, priorityClassName won't be set |
-| args.controllerJobRetentionPolicy | "delete" | Set Job delete/retain behavior of controller after a Job finishes |
+| args.controllerJobRetentionPolicy | "delete" | Determines if the jobs created by kubefledged-controller would be deleted or retained (for debugging) after it finishes. Possible values are 'delete' and 'retain'. default value is 'delete'. |
 | args.controllerServiceAccountName | "" | serviceAccountName used in Jobs created for pulling or deleting images. Optional flag. If not specified the default service account of the namespace is used |
 | args.controllerLogLevel | INFO | Log level of kubefledged-controller |
 | args.webhookServerCertFile | /var/run/secrets/webhook-server/tls.crt | Path of server certificate of kubefledged-webhook-server |

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/templates/deployment-controller.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/templates/deployment-controller.yaml
@@ -45,6 +45,9 @@ spec:
           {{- if .Values.args.controllerJobPriorityClassName }}
             - "--job-priority-class-name={{ .Values.args.controllerJobPriorityClassName }}"
           {{- end }}
+          {{- if .Values.args.controllerJobRetentionPolicy }}
+            - "--job-retention-policy={{ .Values.args.controllerJobRetentionPolicy }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: KUBEFLEDGED_NAMESPACE

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/values.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/values.yaml
@@ -29,6 +29,7 @@ args:
   controllerServiceAccountName: ""
   controllerImageDeleteJobHostNetwork: false
   controllerJobPriorityClassName: ""
+  controllerJobRetentionPolicy: "delete"
   webhookServerLogLevel: INFO
   webhookServerCertFile: /var/run/secrets/webhook-server/tls.crt
   webhookServerKeyFile: /var/run/secrets/webhook-server/tls.key

--- a/docs/helm-parameters.md
+++ b/docs/helm-parameters.md
@@ -18,6 +18,7 @@
 | args.controllerImagePullDeadlineDuration | 5m | Maximum duration allowed for pulling an image. After this duration, image pull is considered to have failed |
 | args.controllerImagePullPolicy | IfNotPresent | Image pull policy for pulling images into and refreshing the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Image with no or ":latest" tag are always pulled |
 | args.controllerJobPriorityClassName | "" | priorityClassName of jobs created by kubefledged-controller. If not specified, priorityClassName won't be set |
+| args.controllerJobRetentionPolicy | "delete" | Set Job delete/retain behavior of controller after a Job finishes |
 | args.controllerServiceAccountName | "" | serviceAccountName used in Jobs created for pulling or deleting images. Optional flag. If not specified the default service account of the namespace is used |
 | args.controllerLogLevel | INFO | Log level of kubefledged-controller |
 | args.webhookServerCertFile | /var/run/secrets/webhook-server/tls.crt | Path of server certificate of kubefledged-webhook-server |

--- a/docs/helm-parameters.md
+++ b/docs/helm-parameters.md
@@ -18,7 +18,7 @@
 | args.controllerImagePullDeadlineDuration | 5m | Maximum duration allowed for pulling an image. After this duration, image pull is considered to have failed |
 | args.controllerImagePullPolicy | IfNotPresent | Image pull policy for pulling images into and refreshing the cache. Possible values are 'IfNotPresent' and 'Always'. Default value is 'IfNotPresent'. Image with no or ":latest" tag are always pulled |
 | args.controllerJobPriorityClassName | "" | priorityClassName of jobs created by kubefledged-controller. If not specified, priorityClassName won't be set |
-| args.controllerJobRetentionPolicy | "delete" | Set Job delete/retain behavior of controller after a Job finishes |
+| args.controllerJobRetentionPolicy | "delete" | Determines if the jobs created by kubefledged-controller would be deleted or retained (for debugging) after it finishes. Possible values are 'delete' and 'retain'. default value is 'delete'. |
 | args.controllerServiceAccountName | "" | serviceAccountName used in Jobs created for pulling or deleting images. Optional flag. If not specified the default service account of the namespace is used |
 | args.controllerLogLevel | INFO | Log level of kubefledged-controller |
 | args.webhookServerCertFile | /var/run/secrets/webhook-server/tls.crt | Path of server certificate of kubefledged-webhook-server |


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

Resolves #101 

This PR adds the '--job-retention-policy' flag to the controller. Possible values for this flag are 'delete' and 'retain'.

delete behavior:
- Delete Image Manager jobs after a Job status is acquired by the lister.

retain behavior:
- Leave Image Manager jobs in the cluster after a Job status is acquired by the lister.