### PR TITLE
Adding additional print columns

### DIFF
--- a/pkg/apis/kubefledged/v1alpha2/types.go
+++ b/pkg/apis/kubefledged/v1alpha2/types.go
@@ -25,6 +25,9 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageCache is a specification for a ImageCache resource
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ImageCache struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This allows for easier debugging when performing a `kubectl get imagecache` such as:

```
$ kubectl get imagecache -A
NAMESPACE     NAME         STATUS      MESSAGE                                                            AGE
kube-fledged   XXXXXXX     Failed      Image pull failed for some images. Please see "failures" section   68m
kube-fledged   XXXXXXX     Failed      Image pull failed for some images. Please see "failures" section   69m
kube-fledged   XXXXXXX      Failed      Image pull failed for some images. Please see "failures" section   74m
kube-fledged   XXXXXXX      Succeeded   All requested images pulled succesfully to respective nodes        83m
kube-fledged   XXXXXXX      Failed      Image pull failed for some images. Please see "failures" section   81m
kube-fledged   XXXXXXX   Failed      Image pull failed for some images. Please see "failures" section   79m
kube-fledged   XXXXXXX        Succeeded   All requested images pulled succesfully to respective nodes        86m
```


I wasn't able to find where/when nor how you were generating the CRD's (only the Clientset and Deepcopy)

