### PR TITLE
feat: allow image list to be empty

### DIFF
--- a/pkg/apis/kubefledged/v1alpha2/types.go
+++ b/pkg/apis/kubefledged/v1alpha2/types.go
@@ -38,7 +38,7 @@ type ImageCache struct {
 
 // CacheSpecImages specifies the Images to be cached
 type CacheSpecImages struct {
-	Images       []string          `json:"images"`
+	Images       []string          `json:"images,omitempty"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 

--- a/pkg/webhook/imagecache.go
+++ b/pkg/webhook/imagecache.go
@@ -102,11 +102,6 @@ func ValidateImageCache(ar v1.AdmissionReview) *v1.AdmissionResponse {
 	glog.V(4).Infof("cacheSpec: %+v", cacheSpec)
 
 	for _, i := range cacheSpec {
-		if len(i.Images) == 0 {
-			glog.Error("No images specified within image list")
-			return toV1AdmissionResponse(fmt.Errorf("No images specified within image list"))
-		}
-
 		for m := range i.Images {
 			for p := 0; p < m; p++ {
 				if i.Images[p] == i.Images[m] {


### PR DESCRIPTION
My use case involves initializing an ImageCache resource out of band, and then having a separate service dynamically add and remove images from the cache. As part of this, I think it would be nice to have the option to initialize the ImageCache resource with CacheSpecs with empty Images lists.