### PR TITLE
FIXED: License.md not found 

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,4 +367,4 @@ Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details on our code of 
 
 ## License
 
-This project is licensed under the Apache 2.0 License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details


### PR DESCRIPTION
Fixed the error caused to change in name of the file from LICENSE.md to LICENSE

fix #221 

![image](https://github.com/senthilrch/kube-fledged/assets/82649533/f6e52ac1-7ec8-4382-a235-097bf8b97c1d)
