### PR TITLE
Fix controller and webhook-server chart templates

### DIFF
--- a/deploy/kubefledged-operator/helm-charts/kubefledged/templates/deployment-controller.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/templates/deployment-controller.yaml
@@ -14,12 +14,12 @@ spec:
       labels:
         {{- include "kubefledged.selectorLabels" . | nindent 8 }}-controller
     spec:
-    {{- if .Values.controller.hostNetwork -}}
+    {{- if .Values.controller.hostNetwork }}
       hostNetwork: true
     {{- end }}
-    {{- if .Values.controller.priorityClassName -}}
+    {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}
-    {{- end }}    
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -50,7 +50,7 @@ spec:
           {{- end }}
           {{- if .Values.args.controllerCRISocketPath }}
             - "--cri-socket-path={{ .Values.args.controllerCRISocketPath }}"
-          {{- end }}          
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: KUBEFLEDGED_NAMESPACE

--- a/deploy/kubefledged-operator/helm-charts/kubefledged/templates/deployment-webhook-server.yaml
+++ b/deploy/kubefledged-operator/helm-charts/kubefledged/templates/deployment-webhook-server.yaml
@@ -15,12 +15,12 @@ spec:
       labels:
         {{- include "kubefledged.selectorLabels" . | nindent 8 }}-webhook-server
     spec:
-    {{- if .Values.webhookServer.hostNetwork -}}
+    {{- if .Values.webhookServer.hostNetwork }}
       hostNetwork: true
     {{- end }}
-    {{- if .Values.webhookServer.priorityClassName -}}
+    {{- if .Values.webhookServer.priorityClassName }}
       priorityClassName: {{ .Values.webhookServer.priorityClassName }}
-    {{- end }}     
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -75,7 +75,7 @@ spec:
             readOnly: true
       volumes:
       - name: certkey-volume
-        emptyDir: {}             
+        emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes incorrect formatting in `deployment-controller.yaml` and `webhook-server.yaml` templates.
Attempting to set `controller` or `webhookServer` section values led to an error

```
Error: YAML parse error on kube-fledged/templates/deployment-webhook-server.yaml: error converting YAML to JSON: yaml: line 26: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 26: mapping values are not allowed in this context
```