### PR TITLE
feat: always return exit code 0

### DIFF
--- a/pkg/images/image_helpers.go
+++ b/pkg/images/image_helpers.go
@@ -100,9 +100,13 @@ func newImagePullJob(imagecache *fledgedv1alpha2.ImageCache, image string, node 
 					},
 					Containers: []corev1.Container{
 						{
-							Name:    "imagepuller",
-							Image:   image,
-							Command: []string{"/tmp/bin/echo", "Image pulled successfully!"},
+							Name:  "imagepuller",
+							Image: image,
+							Command: []string{
+								"/bin/sh",
+								"-c",
+								"/tmp/bin/echo 'Image pulled successfully!' || true",
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "tmp-bin",


### PR DESCRIPTION
### Motivation

Right now the kube-fledged image cache jobs fail when pulled image fails to execute `/tmp/bin/echo Image pulled successfully!`. This is basically true for all container images without a shell like the distroless images.
Therefore, it is either not possible to use it with such images or to get a lot of failed jobs in the cluster.

This PR changes the behaviour to always return true and therefore exit code 0, which allows the usage of all images.