### PR TITLE
v0.11.0 #2: Drop linux/arm/v7 platform support

### DIFF
--- a/.github/workflows/caller.yml
+++ b/.github/workflows/caller.yml
@@ -26,7 +26,7 @@ jobs:
       operator_image_repo: docker.io/senthilrch/kubefledged-operator
       operator_target_platforms: linux/amd64,linux/arm64
       push_image: true
-      target_platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+      target_platforms: linux/amd64,linux/arm64/v8
       webhook_server_image_repo: docker.io/senthilrch/kubefledged-webhook-server
     secrets:
       dockerhub_user: ${{ secrets.DOCKERHUB_USER }}

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ else
 	CGO_ENABLED=0
 endif
 
-GOARM=7
 DOCKER_CLI_EXPERIMENTAL=enabled
 
 ifndef CONTROLLER_IMAGE_REPO
@@ -67,7 +66,7 @@ ifndef RELEASE_VERSION
 endif
 
 ifndef TARGET_PLATFORMS
-  TARGET_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8
+  TARGET_PLATFORMS=linux/amd64,linux/arm64/v8
 endif
 
 ifndef OPERATOR_TARGET_PLATFORMS

--- a/README.md
+++ b/README.md
@@ -320,7 +320,6 @@ For more detailed description, go through _kube-fledged's_ [design proposal](doc
 ## Supported Platforms
 
 - linux/amd64
-- linux/arm
 - linux/arm64
 
 


### PR DESCRIPTION
crictl v1.36.0 no longer provides linux-arm (32-bit) builds. Simplified to linux/amd64 and linux/arm64 for all images.